### PR TITLE
Fix typo in GPL License name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ The HAN-FUN library is released under dual-license : GPLv2 and Apache 2.0
 
 The text for both licenses is presented below.
 
-## GLPv2 [http://www.gnu.org/licenses/gpl-2.0.txt]
+## GPLv2 [http://www.gnu.org/licenses/gpl-2.0.txt]
 
                     GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991


### PR DESCRIPTION
This should probably be GPL and not GLP, I am not a lawyer and I
haven't checked if this change has any legal implications.

Signed-off-by: Hauke Mehrtens hauke.mehrtens@lantiq.com
